### PR TITLE
Removed unused alias in except

### DIFF
--- a/django_translate/middleware.py
+++ b/django_translate/middleware.py
@@ -2,7 +2,7 @@
 
 try:
     from django.utils.deprecation import MiddlewareMixin as BaseClass
-except ImportError, e:
+except ImportError:
     BaseClass = object
 
 from django_translate.services import translator as django_translator


### PR DESCRIPTION
It was breaking compatibility with Python3 (it should be `as` instead of `,`).

As stated in issue #5, the code is currently not compatible with python3. This is a proposed fix.